### PR TITLE
Add Flood depth legend details

### DIFF
--- a/floodresilience/flood_model/templates/viridis_raster.sld
+++ b/floodresilience/flood_model/templates/viridis_raster.sld
@@ -10,14 +10,13 @@ http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
                 <Rule>
                     <RasterSymbolizer>
                         <ColorMap>
-                            <ColorMapEntry color="#fde725" quantity="0" opacity="0" />
-                            <ColorMapEntry color="#fde725" quantity="0.1" opacity="1" />
-                            <ColorMapEntry color="#fde725" quantity="0.1"/>
-                            <ColorMapEntry color="#7ad151" quantity="1"/>
-                            <ColorMapEntry color="#22a884" quantity="2"/>
-                            <ColorMapEntry color="#2a788e" quantity="3"/>
-                            <ColorMapEntry color="#414487" quantity="4"/>
-                            <ColorMapEntry color="#440154" quantity="5"/>
+                            <ColorMapEntry color="#fde725" quantity="0" label="0.0m" opacity="0"/>
+                            <ColorMapEntry color="#fde725" quantity="0.1" label="0.1m" opacity="1"/>
+                            <ColorMapEntry color="#7ad151" quantity="1" label="1.0m"/>
+                            <ColorMapEntry color="#22a884" quantity="2" label="2.0m"/>
+                            <ColorMapEntry color="#2a788e" quantity="3" label="3.0m"/>
+                            <ColorMapEntry color="#414487" quantity="4" label="4.0m"/>
+                            <ColorMapEntry color="#440154" quantity="5" label="5.0m"/>
                         </ColorMap>
                         <Opacity>1.0</Opacity>
                     </RasterSymbolizer>


### PR DESCRIPTION
Adds labels for the flood depth into the legend.

Closes: #12 
- #12 


![image](https://github.com/user-attachments/assets/ae8276d3-5fd5-4c8b-9091-192fa27c1988)

Slightly changes the map to include transparency but the effect is minimal.

## Developer Checklist
- [X] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [X] Comments
  - [ ] Wiki

## Reviewer Checklist
- [x] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [x] Check if documentation needs updating
  - [x] Readme
  - [x] Docstrings
  - [x] Comments
  - [x] Wiki
